### PR TITLE
Add meeting minutes for SVSM Development Call on April 22nd, 2026

### DIFF
--- a/Meetings/README.md
+++ b/Meetings/README.md
@@ -4,6 +4,7 @@
 
 ### April 2026
 
+* [April 22nd, 2026](devel-call-2026-04-22.md)
 * [April 15th, 2026](devel-call-2026-04-15.md)
 * [April 8th, 2026](devel-call-2026-04-08.md)
 * [April 1st, 2026](devel-call-2026-04-01.md)

--- a/Meetings/devel-call-2026-04-22.md
+++ b/Meetings/devel-call-2026-04-22.md
@@ -1,0 +1,21 @@
+# Meeting Minutes: SVSM Development Call (April 22nd, 2026)
+
+## Topics:
+
+### Welcome and Administrative Updates
+
+* **Chairing:** Stefano Garzarella led the meeting as Joerg was out sick.
+* **TSC Status:** Stefano noted that the Technical Steering Committee call did not take place yesterday, so there were no official updates from that body.
+* **Agenda:** No topics were submitted in advance for the current meeting.
+
+### Project Updates
+
+* **VSOCK Merged:** Luigi Leonardi announced that the VSOCK PR has finally been merged after a year of work.
+* **Documentation Issues:** Luigi reported finding new issues within the **SVSM documentation** specifically regarding **attestations**.
+
+### Observability Protocol & GSoC
+
+* **Inquiry:** Eric Mwangi inquired about the implementation plans for the **observability protocol** and whether he could work on it as part of his Google Summer of Code (GSoC) application.
+* **Protocol Status:** The protocol is currently under discussion, led primarily by Joerg, Gerd, and Carlos.
+* **Selection Process:** Stefano clarified that while several people applied for the observability project, Google and the community will officially announce the selected candidate on **April 30th**.
+* **Next Steps:** Eric was encouraged to stay involved by joining discussions and reviewing ongoing work while waiting for the final candidate selection.


### PR DESCRIPTION
Minutes were created from the transcript using AI with some small fixups.