### PR TITLE
Add meeting minutes for SVSM Development Calls on April 29th and May 6th, 2026

### DIFF
--- a/Meetings/README.md
+++ b/Meetings/README.md
@@ -4,6 +4,7 @@
 
 ### April 2026
 
+* [April 29th, 2026](devel-call-2026-04-29.md)
 * [April 22nd, 2026](devel-call-2026-04-22.md)
 * [April 15th, 2026](devel-call-2026-04-15.md)
 * [April 8th, 2026](devel-call-2026-04-08.md)

--- a/Meetings/README.md
+++ b/Meetings/README.md
@@ -2,6 +2,10 @@
 
 ## SVSM Development Call
 
+### May 2026
+
+* [May 6th, 2026](devel-call-2026-05-06.md)
+
 ### April 2026
 
 * [April 29th, 2026](devel-call-2026-04-29.md)

--- a/Meetings/devel-call-2026-04-29.md
+++ b/Meetings/devel-call-2026-04-29.md
@@ -1,0 +1,29 @@
+# Meeting Minutes: SVSM Development Call (April 29th, 2026)
+
+## Topics:
+
+### TSC Meeting Update
+
+* **Security Reporting Process:** Jörg Rödel reported that the current security reporting flow is too dependent on a single inbox and is being revised.
+* **GitHub Vulnerability Reporting:** Private vulnerability reporting is now enabled on the main repository, and previously received reports have been mirrored there for restricted follow-up.
+* **Embargo Policy:** The TSC discussed embargo handling, but deferred decisions because the project is still too early to make firm commitments.
+* **Monthly Release:** The latest monthly development release is already out, so there were no additional release issues to cover.
+* **GDB Usage Question:** The TSC wants feedback from the broader community on whether anyone actively relies on the current GDB-related workflow, because upcoming changes may affect it.
+
+### CCC Annual Project Update Preview
+
+* **Slide Deck Review:** Jörg walked through the slides prepared for the April 30th Confidential Computing Consortium project update.
+* **Scope Wording Update:** The presentation now describes COCONUT as providing secure services for confidential workloads, broadening the framing beyond confidential VMs alone.
+* **Current Execution Modes:** The talk introduces the current modes and uses them to frame later roadmap discussions.
+* **Development Highlights and Metrics:** The presentation includes updated development highlights, contributor and merge statistics, release checkpoints, and OpenSSF scorecard progress.
+* **Roadmap Priorities:** The preview emphasized upstream adoption gaps, persistence support, and work needed to move COCONUT further toward a paravisor-style model.
+* **Broader Workload Direction:** Jörg also outlined ongoing discussion about supporting smaller workloads directly on COCONUT as the project grows.
+* **GSoC Status:** The community is still waiting on Google's acceptance notifications through the QEMU project.
+
+### Project Updates and Discussion
+
+* **Cocoon FS Timeline:** Nicolai Stange said the Cocoon FS work, including the metadata support previously requested by Tyler, should be ready next week or the week after.
+* **Direct Workload Use Cases:** Nicolai asked what kinds of workloads were envisioned for direct execution on SVSM.
+* **Initial Target:** Jörg said the first targets would likely be small workloads rather than database-style applications, and initially may avoid storage-heavy use cases.
+* **Communication Path:** The discussion noted that VSOCK can provide a practical communication mechanism for such workloads even without conventional networking.
+* **Possible Future Runtimes:** The group briefly mentioned small WebAssembly-style runtimes as one possible future direction.

--- a/Meetings/devel-call-2026-05-06.md
+++ b/Meetings/devel-call-2026-05-06.md
@@ -1,0 +1,36 @@
+# Meeting Minutes: SVSM Development Call (May 6th, 2026)
+
+## Topics:
+
+### TSC Meeting Update
+
+* **Memory Ordering PR:** Jörg reported that the memory-ordering discussion around `PR1051` was resolved, with the relevant swap operation needing acquire-release semantics rather than release-only semantics.
+* **CCC Project Update:** The Confidential Computing Consortium reacted positively to COCONUT's growth in contributors, merged PRs, and improved security posture, including CI and OpenSSF scorecard progress.
+* **Broader Workload Direction:** The CCC discussion focused on COCONUT's expanded scope beyond an SVSM toward running smaller confidential workloads and basic Linux binaries directly.
+* **Possible Gramine Collaboration:** The overlap with Gramine's goal of running unmodified Linux applications prompted discussion about possible collaboration, though the Rust-versus-C language split was noted as a practical barrier.
+* **Security Reports:** The TSC reviewed newly received security reports and is working on mitigations, with more details expected later.
+* **GSoC Acceptance:** Both COCONUT-related Google Summer of Code projects were accepted, students have started engaging with the community, and project work is expected to begin on May 25.
+* **AI-Generated PR Policy:** The group discussed how to handle AI-generated or AI-assisted pull requests after `PR1049`, reaffirming that AI-assisted code is allowed but pull requests must still be submitted by a human to satisfy DCO requirements.
+
+### PRs and Issue Triage
+
+* **Bootloader Changes Merged:** Jon's bootloader series was considered ready and has already been merged, with any remaining review feedback to be handled as follow-up fixes.
+* **PR Dependency Review:** The TSC also reviewed several other open pull requests to clarify status and dependencies between them.
+* **VGA Boot Failure:** The group revisited the issue where attaching a VGA device in QEMU causes SVSM boot failures, likely in the accept-pages path, and agreed that more investigation is still needed.
+* **Secrets Zeroing Issue:** Another issue discussed was the report about secrets not being cleared correctly; Stefano said he would continue the follow-up in the issue tracker.
+* **TSC Context Shared:** Jörg explained for newer participants that the TSC is a four-person shared maintainership group that meets weekly to handle governance, merges, issue tracking, and security follow-up.
+
+### vTPM Attestation Manifest Discussion
+
+* **Manifest v1 Questions:** Jacob Xu raised questions about implementing the updated vTPM service manifest, which now expects a list of signing and storage keys rather than the single-key behavior in the earlier version.
+* **Interactive vs. Fixed Lists:** The main design discussion compared an interactive protocol where the requester provides a template against a fixed or vendor-specific list of attested templates or keys.
+* **Protocol Size Constraint:** James Bottomley noted that the current attestation request format likely does not have enough input space to carry arbitrary template data, which may explain why the interactive approach was rejected previously.
+* **Names vs. Public Areas:** The group also discussed attesting TPM names instead of full public key areas to reduce size, with the caveat that some approaches may require regenerating keys.
+* **Next Step:** Jörg suggested moving the open design questions to the mailing list first and opening a GitHub issue later once the direction is clearer and implementation work can be tracked concretely.
+
+### Verification and Refactoring
+
+* **Page Table Refactor:** Ziqiaozhou asked about splitting generic x86 page-table code from COCONUT-specific code to support formal verification and possible reuse by other projects; Jörg said that direction was fine as long as it does not conflict with future multi-architecture cleanup.
+* **Verification CI Cost:** Ziqiaozhou also reported that the verification CI currently installs both Z3 and Verus, with Z3 taking the most time.
+* **Caching Follow-Up:** Jörg said the current CI cost is acceptable for now, but caching Verus artifacts similar to the QEMU workflow would be a useful optimization later.
+* **Local Setup Convenience:** Stefano asked whether local developers could still use prebuilt tooling, and Ziqiaozhou said that keeping a path for local prebuilt installs would be helpful.


### PR DESCRIPTION
Minutes were created from the transcript using AI with some small fixups.